### PR TITLE
Changes Related to Github Transfer & Extend Documentation For User Signup Lambda

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ format-terraform:
 	terraform fmt -recursive -diff .
 
 .private:
-	git clone git@github.com:alphagov/govwifi-build.git .private
+	git clone git@github.com:GovWifi/govwifi-build.git .private
 
 update-secrets: .private
 	cd .private && git pull

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Our services include:
 - A Prometheus server to scrape metrics from the FreeRADIUS Prometheus Exporters which exposes FreeRADIUS server data
 
 We manage our infrastructure via:
-- Terraform, split across this repository and [govwifi-build](https://github.com/alphagov/govwifi-build)
+- Terraform, split across this repository and [govwifi-build](https://github.com/GovWifi/govwifi-build)
 - The [safe restarter](https://github.com/alphagov/govwifi-safe-restarter), which uses a [CanaryRelease](https://martinfowler.com/bliki/CanaryRelease.html) strategy to increase the stability of the frontends
 
 Other repositories:
@@ -37,7 +37,7 @@ Secret credentials are stored in AWS Secrets Manager in the format of `<service>
 
 `service` will be the GovWifi service (admin, radius, user-signup, logging) related to that secret. If the secret is not specific to a GovWifi service, use the AWS service or product it relates to (e.g., rds, s3, grafana).
 
-For historical use of secrets  please see: [GovWifi build](https://github.com/alphagov/govwifi-build). This is now used to store non secret but sensitive information such as IP ranges.
+For historical use of secrets  please see: [GovWifi build](https://github.com/GovWifi/govwifi-build). This is now used to store non secret but sensitive information such as IP ranges.
 
 ## Running terraform for the first time
 
@@ -189,7 +189,7 @@ The APP_ENV environment variable for any new GovWifi environment should be set t
 #### Update Govwifi-Build
 
 ##### Add A Directory For Your New Environment
-We keep sensitive (but non secret information) in a private repo called govwifi-build(https://github.com/alphagov/govwifi-build). This folder is only accessible to GovWifi team members.  If you create a new GovWifi environment you will need to add new directory of the same name [here](https://github.com/alphagov/govwifi-build/tree/master/non-encrypted/secrets-to-copy/govwifi).
+We keep sensitive (but non secret information) in a private repo called govwifi-build(https://github.com/GovWifi/govwifi-build). This folder is only accessible to GovWifi team members.  If you create a new GovWifi environment you will need to add new directory of the same name [here](https://github.com/GovWifi/govwifi-build/tree/master/non-encrypted/secrets-to-copy/govwifi).
 Instructions
 - Make a copy of the staging directory and rename it to your environment name
 
@@ -198,7 +198,7 @@ cp -Rp non-encrypted/secrets-to-copy/govwifi/staging non-encrypted/secrets-to-co
 ```
 
 - Replace any references to `staging` in the newly created directory with your new environment name.
-[See here for an example commit](https://github.com/alphagov/govwifi-build/pull/541/files#diff-3382ad2da7f814e1bbd3a3ae321be41d7e23db80734611bb4ac90ab30d690cc5).
+[See here for an example commit](https://github.com/GovWifi/govwifi-build/pull/541/files#diff-3382ad2da7f814e1bbd3a3ae321be41d7e23db80734611bb4ac90ab30d690cc5).
 
 ```
 for filename in ./non-encrypted/secrets-to-copy/govwifi/<NEW-ENV-NAME>/* ; do sed -i '' 's/staging/<NEW-ENV-NAME>/g' $filename ; done

--- a/govwifi-account-policy/buildspec.yml
+++ b/govwifi-account-policy/buildspec.yml
@@ -1,12 +1,12 @@
 version: 0.2
 phases:
-    pre_build:
-        commands:
-            - echo "Pulling script from github"
-            - git clone https://github.com/alphagov/govwifi-terraform.git
-            - cd govwifi-terraform
+  pre_build:
+    commands:
+      - echo "Pulling script from github"
+      - git clone https://github.com/GovWifi/govwifi-terraform.git
+      - cd govwifi-terraform
 
-    build:
-        commands:
-            - echo "Running script"
-            - ./govwifi-account-policy/disable-inactive-iam-keys.sh
+  build:
+    commands:
+      - echo "Running script"
+      - ./govwifi-account-policy/disable-inactive-iam-keys.sh

--- a/govwifi-api/README.md
+++ b/govwifi-api/README.md
@@ -1,0 +1,38 @@
+# User Sign Up Lambda
+
+The code for the user signup lambda is kept in this repo:
+https://github.com/GovWifi/govwifi-lambda-for-user-signup-api
+
+This code needs to be turned into a zip file and added to this directory. Further instructions can be found in the [repo README](https://github.com/GovWifi/govwifi-lambda-for-user-signup-api).
+
+## Reasons For Adding This Lambda User Sign Up
+
+Previously the User signup API security groups were too open. They were
+restricted by port but not by source. It is better to lockdown the ingress
+traffic to specific known IPs, rather than to allow traffic from any source to
+reach the app. We only want traffic from
+Notify(https://www.notifications.service.gov.uk/) and our SNS user signup
+notifications topic to reach our User Signup API app.
+
+## How This Works
+Restricting traffic that originates from SNS is not a simple task, this is because SNS does not operate inside a VPC, and therefore we cannot simply restrict traffic to a single IP (or small set of IPS). After some discussion we decided the simplest way to
+achieve what we wanted, was to add an AWS lambda function between SNS and the
+User signup API ECS task. The full details of the conversations with AWS have
+been documented in the comment section of the Trello card linked at the bottom
+of this message. [There is also an in-depth DRD(Decision Requirements Diagram)]
+(https://docs.google.com/document/d/1mQIDjVehcNa13paqjHWGylCVY5RoUcnnif0Uv_5l_Lk/edit#)
+
+
+## To achieve this the following was added:
+
+- A lambda function, which forwards any messages sent via SNS to the User Sign, and the appropriate IAM roles/permissions to do so.
+- A Lambda SNS trigger to replace our current https trigger.
+- Three private subnets in the AWS London(eu-west-2) region (one for each
+availability zone) that the lambda will exist in.
+- Three new NAT gateways (to
+allow egress traffic from each of new private subnets to the User Signup API
+)
+- Three new EIPs for the NAT gateways
+- Three route tables (please see [the DRD](https://docs.google.com/document/d/1mQIDjVehcNa13paqjHWGylCVY5RoUcnnif0Uv_5l_Lk/edit?tab=t.0#heading=h.suvkszxbqg7q) for information on why three in particular were necessary)
+- New ingress rules to the User Sign Up API security group, allowing traffic from the EIP
+associated with the new NAT gateways and Notify’s egress IPs.

--- a/govwifi-api/lambdas.tf
+++ b/govwifi-api/lambdas.tf
@@ -7,6 +7,8 @@ resource "aws_lambda_function" "user_api_sns_lambda" {
   description   = "This lambda forwards traffic from SNS to the user-signup-api"
 
   source_code_hash = filebase64sha256("../../govwifi-api/user_api_sns_lambda.zip")
+  # The unzipped source code can be found at: https://github.com/GovWifi/govwifi-lambda-for-user-signup-api
+  # Documentation can found in the README of this directory
 
   runtime       = "python3.8"
   architectures = ["x86_64"]

--- a/govwifi-prometheus/prometheus-govwifi
+++ b/govwifi-prometheus/prometheus-govwifi
@@ -1,6 +1,6 @@
 [Unit]
 Description=Starts prometheus with the options needed by govwifi
-Documentation=https://github.com/alphagov/govwifi-terraform/blob/master/README.md
+Documentation=https://github.com/GovWifi/govwifi-terraform/blob/master/README.md
 
 [Service]
 Restart=always

--- a/govwifi-sync-certs/buildspec.yml
+++ b/govwifi-sync-certs/buildspec.yml
@@ -1,18 +1,18 @@
 version: 0.2
 phases:
-    pre_build:
-        commands:
-              - echo "$DOCKER_HUB_AUTHTOKEN_ENV" | docker login -u $(echo $DOCKER_HUB_USERNAME_ENV) --password-stdin
-              - apt-get update -y
-              - apt-get install pass -y
-              - git clone https://$GIT_USER:$GIT_TOKEN@github.com/alphagov/govwifi-build.git
-              - cd govwifi-build
-              - echo "Set params"
+  pre_build:
+    commands:
+      - echo "$DOCKER_HUB_AUTHTOKEN_ENV" | docker login -u $(echo $DOCKER_HUB_USERNAME_ENV) --password-stdin
+      - apt-get update -y
+      - apt-get install pass -y
+      - git clone https://$GIT_USER:$GIT_TOKEN@github.com/GovWifi/govwifi-build.git
+      - cd govwifi-build
+      - echo "Set params"
 
-    build:
-        commands:
-            - echo "Synching certificates for $GOVWIFI_ENV"
-            - REGION=$AWS_REGION
-            - echo "Syncing certs. REGION is set to $REGION"
-            - CERTSDIR="$GOVWIFI_ENV"
-            - ci/tasks/scripts/sync-certs.sh #run script
+  build:
+    commands:
+      - echo "Synching certificates for $GOVWIFI_ENV"
+      - REGION=$AWS_REGION
+      - echo "Syncing certs. REGION is set to $REGION"
+      - CERTSDIR="$GOVWIFI_ENV"
+      - ci/tasks/scripts/sync-certs.sh #run script

--- a/govwifi/tools/.terraform.lock.hcl
+++ b/govwifi/tools/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   version = "5.62.0"
   hashes = [
     "h1:8tevkFG+ea/sNZYiQ2GQ02hknPcWBukxkrpjRCodQC0=",
+    "h1:X3LAZdkVhb/77gTlhPwKYCA9oblBCSu866fZDDOojPY=",
     "zh:1f366cbcda72fb123015439a42ab19f96e10ce4edb404273f4e1b7e06da20b73",
     "zh:25f098454a34b483279e0382b24b4f42e51c067222c6e797eda5d3ec33b9beb1",
     "zh:4b59d48b527e3cefd73f196853bfc265b3e1e57b55c1c8a2d12ff6e3534b4f07",


### PR DESCRIPTION
### What
Changes Related to Github Transfer & Extend Documentation For User Signup Lambda

### Why
Update Alphagov related links
Add Extended documentation For User Signup Lambda
Also add link to code in repo

### Link to JIRA card (if applicable): 
https://technologyprogramme.atlassian.net/jira/software/projects/GW/boards/251?assignee=5e45277d29e6d00c970616c6&selectedIssue=GW-1841&sprintStarted=true