### PR TITLE
Updates to codebuild acceptance tests project

### DIFF
--- a/govwifi-deploy/buildspec_acceptance_tests.yml
+++ b/govwifi-deploy/buildspec_acceptance_tests.yml
@@ -1,11 +1,11 @@
 version: 0.2
 phases:
-    pre_build:
-        commands:
-              - echo "$DOCKER_HUB_AUTHTOKEN_ENV" | docker login -u $(echo $DOCKER_HUB_USERNAME_ENV) --password-stdin
-    build:
-        commands:
-            - echo "Acceptance tests running"
-            - git clone https://github.com/alphagov/govwifi-acceptance-tests.git
-            - cd govwifi-acceptance-tests
-            - make test
+  pre_build:
+    commands:
+      - echo "$DOCKER_HUB_AUTHTOKEN_ENV" | docker login -u $(echo $DOCKER_HUB_USERNAME_ENV) --password-stdin
+  build:
+    commands:
+      - echo "Acceptance tests running"
+      - git clone https://github.com/govwifi/govwifi-acceptance-tests.git
+      - cd govwifi-acceptance-tests
+      - make test

--- a/govwifi-deploy/codebuild-acceptance-tests.tf
+++ b/govwifi-deploy/codebuild-acceptance-tests.tf
@@ -11,7 +11,7 @@ resource "aws_codebuild_project" "govwifi_codebuild_acceptance_tests" {
 
   environment {
     compute_type                = "BUILD_GENERAL1_SMALL"
-    image                       = "aws/codebuild/standard:6.0"
+    image                       = "aws/codebuild/standard:7.0"
     type                        = "LINUX_CONTAINER"
     image_pull_credentials_type = "CODEBUILD"
     privileged_mode             = true


### PR DESCRIPTION
### What
Update Codebuild Image For Acceptance Tests
Also update address of github repo. 

### Why
We are migrating our code to our own github org
The codebuild image was updated as the "docker compose" command was not recognised on older AWS codebuild images

### Link to JIRA card (if applicable): 
https://technologyprogramme.atlassian.net/jira/software/projects/GW/boards/251?assignee=5e45277d29e6d00c970616c6&selectedIssue=GW-1848&sprintStarted=true