### PR TITLE
fix: [GW-2049] get acceptance tests to work.

### DIFF
--- a/govwifi-deploy/alpaca-codebuild-built-apps.tf
+++ b/govwifi-deploy/alpaca-codebuild-built-apps.tf
@@ -2,7 +2,7 @@ resource "aws_codebuild_project" "alpaca_govwifi_codebuild_built_app" {
   for_each       = toset(var.built_app_names)
   name           = "${each.key}-push-docker-image-to-alpaca-ECR"
   description    = "This project builds the ${each.key} image and pushes it to ECR"
-  build_timeout  = "12"
+  build_timeout  = "20"
   service_role   = aws_iam_role.govwifi_codebuild.arn
   encryption_key = aws_kms_key.codepipeline_key.arn
 
@@ -33,13 +33,13 @@ resource "aws_codebuild_project" "alpaca_govwifi_codebuild_built_app" {
     }
 
     environment_variable {
-      name  = "ACCEPTANCE_TESTS_PROJECT_NAME"
-      value = aws_codebuild_project.govwifi_codebuild_acceptance_tests.name
+      name  = "STAGE"
+      value = "alpaca"
     }
 
     environment_variable {
-      name  = "STAGE"
-      value = "alpaca"
+      name  = "ACCEPTANCE_TESTS_PROJECT_NAME"
+      value = aws_codebuild_project.govwifi_codebuild_acceptance_tests.name
     }
 
   }

--- a/govwifi-deploy/codebuild-deployed-apps.tf
+++ b/govwifi-deploy/codebuild-deployed-apps.tf
@@ -2,7 +2,7 @@ resource "aws_codebuild_project" "govwifi_codebuild_deployed_app" {
   for_each       = toset(var.deployed_app_names)
   name           = "${each.key}-app-build-push-image-ECR"
   description    = "This project builds the ${each.key} app docker image and pushes it to ECR"
-  build_timeout  = "12"
+  build_timeout  = "20"
   service_role   = aws_iam_role.govwifi_codebuild.arn
   encryption_key = aws_kms_key.codepipeline_key.arn
 
@@ -30,6 +30,11 @@ resource "aws_codebuild_project" "govwifi_codebuild_deployed_app" {
     environment_variable {
       name  = "AWS_ACCOUNT_ID"
       value = local.aws_account_id
+    }
+
+    environment_variable {
+      name  = "ACCEPTANCE_TESTS_PROJECT_NAME"
+      value = aws_codebuild_project.govwifi_codebuild_acceptance_tests.name
     }
   }
 


### PR DESCRIPTION
### What
Add missing acceptance test env var and extend timeout, this is temporary, as this will be moved to it's own pipeline stage in another ticket.

### Why
The build times out as it doesn't wait long enough, and currently the AC tests are missing from Auth and Logging api's


### Link to JIRA card (if applicable): 
[GW-2049](https://technologyprogramme.atlassian.net/browse/GW-2049)