### PR TITLE
GW-2062: Added an IAM Role for application insights for sending logs to Cyber Splunk

### DIFF
--- a/govwifi-account/iam-roles.tf
+++ b/govwifi-account/iam-roles.tf
@@ -409,7 +409,7 @@ POLICY
 resource "aws_iam_role" "AWSServiceRoleForCloudWatchForCybersecurity" {
   name        = "AWSServiceRoleForCloudWatchForCybersecurity"
   path        = "/aws-service-role/application-insights.amazonaws.com/"
-  description = "Allows Kinesis Firehose and Lambda to assume CloudWatch-AppInsights role to send data to Kinesis Data Stream from Cloudwatch Logs for CyberSecurity Team.",
+  description = "Allows Kinesis Firehose and Lambda to assume CloudWatch-AppInsights role to send data to Kinesis Data Stream from Cloudwatch Logs for CyberSecurity Team."
 
   assume_role_policy = <<POLICY
 {

--- a/govwifi-account/iam-roles.tf
+++ b/govwifi-account/iam-roles.tf
@@ -404,3 +404,28 @@ resource "aws_iam_role_policy" "SNSSuccessFeedback_oneClick_SNSSuccessFeedback_1
 POLICY
 
 }
+
+
+resource "aws_iam_role" "AWSServiceRoleForCloudWatchForCybersecurity" {
+  name        = "AWSServiceRoleForCloudWatchForCybersecurity"
+  path        = "/aws-service-role/application-insights.amazonaws.com/"
+  description = "Allows Kinesis Firehose and Lambda to assume CloudWatch-AppInsights role to send data to Kinesis Data Stream from Cloudwatch Logs for CyberSecurity Team.",
+
+  assume_role_policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": [
+          "application-insights.amazonaws.com",
+        ]
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+POLICY
+
+}

--- a/govwifi-account/iam-roles.tf
+++ b/govwifi-account/iam-roles.tf
@@ -419,7 +419,7 @@ resource "aws_iam_role" "AWSServiceRoleForCloudWatchForCybersecurity" {
       "Effect": "Allow",
       "Principal": {
         "Service": [
-          "application-insights.amazonaws.com",
+          "application-insights.amazonaws.com"
         ]
       },
       "Action": "sts:AssumeRole"


### PR DESCRIPTION
### What
Added an IAM Role for Application Insights 

### Why
So the role can be used to send failed admin login attempts logs to Cyber Splunk


### Link to JIRA card (if applicable): 
[GW-2062](https://technologyprogramme.atlassian.net/browse/GW-2062)