### PR TITLE
GW-2026 Removed the role from govwifi-account to govwifi-account-policy

### DIFF
--- a/govwifi-account-policy/iam.tf
+++ b/govwifi-account-policy/iam.tf
@@ -63,3 +63,26 @@ resource "aws_iam_role_policy_attachment" "iam_management" {
   policy_arn = aws_iam_policy.iam_management[0].arn
 }
 
+resource "aws_iam_role" "govwifi_cloudwatch_for_cybersecurity" {
+  name        = "GovwifiRoleForCloudWatchForCybersecurity"
+  description = "Allows Kinesis Firehose and Lambda to assume CloudWatch-AppInsights role to send data to Kinesis Data Stream from Cloudwatch Logs for CyberSecurity Team."
+  path  = "/"
+
+  assume_role_policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": [
+          "application-insights.amazonaws.com"
+        ]
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+POLICY
+
+}

--- a/govwifi-account/iam-roles.tf
+++ b/govwifi-account/iam-roles.tf
@@ -404,28 +404,3 @@ resource "aws_iam_role_policy" "SNSSuccessFeedback_oneClick_SNSSuccessFeedback_1
 POLICY
 
 }
-
-
-resource "aws_iam_role" "AWSServiceRoleForCloudWatchForCybersecurity" {
-  name        = "AWSServiceRoleForCloudWatchForCybersecurity"
-  path        = "/aws-service-role/application-insights.amazonaws.com/"
-  description = "Allows Kinesis Firehose and Lambda to assume CloudWatch-AppInsights role to send data to Kinesis Data Stream from Cloudwatch Logs for CyberSecurity Team."
-
-  assume_role_policy = <<POLICY
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect": "Allow",
-      "Principal": {
-        "Service": [
-          "application-insights.amazonaws.com"
-        ]
-      },
-      "Action": "sts:AssumeRole"
-    }
-  ]
-}
-POLICY
-
-}


### PR DESCRIPTION
### What
Removed the role from govwifi-account to govwifi-account-policy

### Why
govwifi-account is not imported as module in terraform


### Link to JIRA card (if applicable): 
[GW-2062](https://technologyprogramme.atlassian.net/browse/GW-2062)