### PR TITLE
remove legacy log groups

### DIFF
--- a/govwifi-backend/db-sessions.tf
+++ b/govwifi-backend/db-sessions.tf
@@ -25,7 +25,7 @@ resource "aws_db_instance" "db" {
   skip_final_snapshot         = true
   deletion_protection         = true
 
-  enabled_cloudwatch_logs_exports = ["audit", "error", "general", "slowquery"]
+  enabled_cloudwatch_logs_exports = ["error"]
   option_group_name               = "default:mysql-8-0"
   parameter_group_name            = "default.mysql8.0"
 

--- a/govwifi-backend/db-users.tf
+++ b/govwifi-backend/db-users.tf
@@ -25,7 +25,7 @@ resource "aws_db_instance" "users_db" {
   skip_final_snapshot         = true
   deletion_protection         = true
 
-  enabled_cloudwatch_logs_exports = ["error", "general", "slowquery"]
+  enabled_cloudwatch_logs_exports = ["error", "slowquery"]
   option_group_name               = aws_db_option_group.user_mariadb_audit[0].name
   parameter_group_name            = aws_db_parameter_group.user_db_parameters[0].name
 


### PR DESCRIPTION
### What
Remove legacy log groups from our codebase

### Why
The log groups contained zero data

### Testing
Tested fully using Alpaca.
To test, pull the branch, terraform 'plan' against an AWS account, check to see log group config would be removed 

### Link to JIRA card (if applicable): 
[[GW-xxx](https://technologyprogramme.atlassian.net/browse/GW-xxx)](https://technologyprogramme.atlassian.net/jira/software/projects/GW/boards/251?assignee=5b2a20739ba6d02662e2fc0b&selectedIssue=GW-1906)