### PR TITLE
fix: [GW-2099]allow custom branch for smoke tests

### DIFF
--- a/govwifi-smoke-tests/buildspec.yml
+++ b/govwifi-smoke-tests/buildspec.yml
@@ -2,10 +2,10 @@ version: 0.2
 phases:
   pre_build:
     commands:
-      - echo "$DOCKER_HUB_AUTHTOKEN_ENV" | docker login -u $(echo $DOCKER_HUB_USERNAME_ENV) --password-stdin
+    - echo "$DOCKER_HUB_AUTHTOKEN_ENV" | docker login -u $(echo $DOCKER_HUB_USERNAME_ENV) --password-stdin
+    - git clone -b $BRANCH https://github.com/GovWifi/govwifi-smoke-tests.git
   build:
     commands:
-      - echo "Smoke-tests running"
-      - git clone https://github.com/GovWifi/govwifi-smoke-tests.git
-      - cd govwifi-smoke-tests
-      - make test
+    - echo "Smoke-tests running"
+    - cd govwifi-smoke-tests
+    - make test

--- a/govwifi-smoke-tests/codebuild.tf
+++ b/govwifi-smoke-tests/codebuild.tf
@@ -15,6 +15,12 @@ resource "aws_codebuild_project" "smoke_tests" {
     image_pull_credentials_type = "CODEBUILD"
     privileged_mode             = true
 
+    ## Use this to over ride the branch, unable to use the normal source method as accounts would need github access.
+    environment_variable {
+      name  = "BRANCH" 
+      value = "master"
+    }
+
     environment_variable {
       name  = "DOCKER_HUB_AUTHTOKEN_ENV"
       value = data.aws_secretsmanager_secret_version.docker_hub_authtoken.secret_string
@@ -163,7 +169,7 @@ resource "aws_cloudwatch_event_target" "trigger_smoke_tests" {
 
 # Enable scheduled smoke tests in production environment only
 resource "aws_cloudwatch_event_rule" "smoke_tests_schedule_rule" {
-  is_enabled          = var.env == "wifi" ? true : false
+  state          = var.env == "wifi" ? "ENABLED" : "DISABLED"
   name                = "smoke-tests-scheduled-build"
   schedule_expression = "cron(0/15 * * * ? *)"
 }

--- a/govwifi-smoke-tests/codebuild.tf
+++ b/govwifi-smoke-tests/codebuild.tf
@@ -10,7 +10,7 @@ resource "aws_codebuild_project" "smoke_tests" {
 
   environment {
     compute_type                = "BUILD_GENERAL1_SMALL"
-    image                       = "aws/codebuild/standard:5.0"
+    image                       = "aws/codebuild/standard:7.0"
     type                        = "LINUX_CONTAINER"
     image_pull_credentials_type = "CODEBUILD"
     privileged_mode             = true
@@ -18,7 +18,7 @@ resource "aws_codebuild_project" "smoke_tests" {
     ## Use this to over ride the branch, unable to use the normal source method as accounts would need github access.
     environment_variable {
       name  = "BRANCH" 
-      value = "master"
+      value = "main"
     }
 
     environment_variable {


### PR DESCRIPTION
### What
Add a variable to allow custom branch

### Why
So we can test changes to the smoke tests without having to merge to master first, not unable to use github as a source like other codebuilds as dev doesn't have github access.


### Link to JIRA card (if applicable): 
[GW-2099](https://technologyprogramme.atlassian.net/browse/GW-2099)