### PR TITLE
Schedule rake task to publish organisation names to an S3 bucket

### DIFF
--- a/govwifi-admin/scheduled-tasks.tf
+++ b/govwifi-admin/scheduled-tasks.tf
@@ -272,3 +272,49 @@ resource "aws_cloudwatch_event_target" "export_certificates" {
 EOF
 
 }
+
+# rake publish_organisation_names
+
+resource "aws_cloudwatch_event_rule" "daily_publish_organisation_names" {
+  name                = "${var.env_name}-daily-publish-organisation-names"
+  description         = "Triggers daily 22:00 UTC"
+  schedule_expression = "cron(00 22 * * ? *)"
+  is_enabled          = true
+}
+
+resource "aws_cloudwatch_event_target" "publish_organisation_names" {
+  target_id = "${var.env_name}-publish-organisation-names"
+  arn       = aws_ecs_cluster.admin_cluster.arn
+  rule      = aws_cloudwatch_event_rule.daily_publish_organisation_names.name
+  role_arn  = aws_iam_role.scheduled_task.arn
+
+  ecs_target {
+    task_count          = 1
+    task_definition_arn = aws_ecs_task_definition.admin_task.arn
+    launch_type         = "FARGATE"
+    platform_version    = "1.4.0"
+
+    network_configuration {
+      subnets = var.subnet_ids
+
+      security_groups = concat(
+        [aws_security_group.admin_ec2_in.id],
+        [aws_security_group.admin_ec2_out.id]
+      )
+
+      assign_public_ip = true
+    }
+  }
+
+  input = <<EOF
+{
+  "containerOverrides": [
+    {
+      "name": "admin",
+      "command": ["bundle", "exec", "rake", "publish_organisation_names"]
+    }
+  ]
+}
+EOF
+
+}


### PR DESCRIPTION
### What
Run the `publish_organisation_names` rake task on `govwifi-admin` every day at 22:00 UTC.

### Why
The product page should reflect the correct and up-to-date organisations that offer GovWifi


### Link to JIRA card (if applicable): 
[GW-2088](https://technologyprogramme.atlassian.net/browse/GW-2088)