### PR TITLE
Schedule the task to upload notification templates to an S3 bucket

### DIFF
--- a/govwifi-api/cloudwatch-events.tf
+++ b/govwifi-api/cloudwatch-events.tf
@@ -79,6 +79,14 @@ resource "aws_cloudwatch_event_rule" "retrieve_notifications_event" {
   state               = "ENABLED"
 }
 
+resource "aws_cloudwatch_event_rule" "backup_notify_templates_event" {
+  count               = var.event_rule_count
+  name                = "${var.env_name}-backup-notify-templates"
+  description         = "Triggers daily 06:00 UTC"
+  schedule_expression = "cron(0 6 * * ? *)"
+  state               = "ENABLED"
+}
+
 resource "aws_cloudwatch_event_rule" "active_users_signup_survey_event" {
   count               = var.event_rule_count
   name                = "${var.env_name}-active-users-signup-survey"

--- a/govwifi-api/user-signup-api-cluster.tf
+++ b/govwifi-api/user-signup-api-cluster.tf
@@ -131,6 +131,9 @@ resource "aws_ecs_task_definition" "user_signup_api_task" {
           "name": "S3_SIGNUP_ALLOWLIST_OBJECT_KEY",
           "value": "signup-allowlist.conf"
         },{
+          "name": "S3_NOTIFICATION_TEMPLATES_BUCKET",
+          "value": "${var.app_env}_notification_templates"
+        },{
           "name": "FIRETEXT_TOKEN",
           "value": "${var.firetext_token}"
         }

--- a/govwifi-api/user-signup-scheduled-tasks.tf
+++ b/govwifi-api/user-signup-scheduled-tasks.tf
@@ -37,6 +37,44 @@ EOF
 
 }
 
+resource "aws_cloudwatch_event_target" "backup_notify_templates" {
+  count     = var.user_signup_enabled
+  target_id = "${var.env_name}-backup-notify-templates"
+  arn       = aws_ecs_cluster.api_cluster.arn
+  rule      = aws_cloudwatch_event_rule.backup_notify_templates_event[0].name
+  role_arn  = aws_iam_role.user_signup_scheduled_task_role[0].arn
+
+  ecs_target {
+    task_count          = 1
+    task_definition_arn = aws_ecs_task_definition.user_signup_api_scheduled_task[0].arn
+    launch_type         = "FARGATE"
+    platform_version    = "1.4.0"
+
+    network_configuration {
+      subnets = var.subnet_ids
+
+      security_groups = concat(
+        [aws_security_group.api_in.id],
+        [aws_security_group.api_out.id],
+      )
+
+      assign_public_ip = true
+    }
+  }
+
+  input = <<EOF
+{
+  "containerOverrides": [
+    {
+      "name": "user-signup-api",
+      "command": ["bundle", "exec", "rake", "backup_notify_templates"]
+    }
+  ]
+}
+EOF
+
+}
+
 resource "aws_iam_role" "user_signup_scheduled_task_role" {
   count = var.user_signup_enabled
   name  = "${var.env_name}-user-signup-scheduled-task-role"


### PR DESCRIPTION
### What

Run the `backup_notify_templates` rake task on `govwifi-user-signup-api` every day at 06:00 UTC.

### Why

To back up and recover our Notify templates, in case there is a DR scenario


### Link to JIRA card (if applicable): 
[GW-1821](https://technologyprogramme.atlassian.net/browse/GW-1821)