### PR TITLE
disable cross zone traffic redirection post incident

### DIFF
--- a/govwifi-frontend/load-balancer.tf
+++ b/govwifi-frontend/load-balancer.tf
@@ -2,7 +2,7 @@ resource "aws_lb" "main" {
   name               = "frontend"
   load_balancer_type = "network"
 
-  enable_cross_zone_load_balancing = true
+  enable_cross_zone_load_balancing = false
 
   dynamic "subnet_mapping" {
     for_each = [for subnet in aws_subnet.wifi_frontend_subnet : subnet.id]


### PR DESCRIPTION
### What
Disable Cross Zone traffic redirection

### Why
This was a contributory cause in the May incident.
With the improved infrastructure (9+9 containers) we need to remove this.

### Notes
Tested in Staging and Development.
Deployment to Production will require out of hours. Estimating max impact is several seconds and traffic redirected to the other region.

### Link to JIRA card (if applicable): 
https://technologyprogramme.atlassian.net/jira/software/projects/GW/boards/251?assignee=5b2a20739ba6d02662e2fc0b&selectedIssue=GW-2336