### PR TITLE
Feature/gw 2334 extend log retension

### DIFF
--- a/govwifi/alpaca/locals.tf
+++ b/govwifi/alpaca/locals.tf
@@ -5,7 +5,7 @@ locals {
   product_name  = "GovWifi"
 
   backup_mysql_rds = true
-  log_retention    = 90
+  log_retention    = 30
 }
 
 locals {

--- a/govwifi/alpaca/locals.tf
+++ b/govwifi/alpaca/locals.tf
@@ -5,7 +5,7 @@ locals {
   product_name  = "GovWifi"
 
   backup_mysql_rds = true
-  log_retention    = 30
+  log_retention    = 90
 }
 
 locals {

--- a/govwifi/staging/locals.tf
+++ b/govwifi/staging/locals.tf
@@ -5,7 +5,7 @@ locals {
   product_name  = "GovWifi"
 
   backup_mysql_rds = true
-  log_retention    = 30
+  log_retention    = 90
 }
 
 locals {

--- a/govwifi/wifi-london/locals.tf
+++ b/govwifi/wifi-london/locals.tf
@@ -7,7 +7,7 @@ locals {
 
   backup_mysql_rds              = true
   london_backend_vpc_cidr_block = "10.84.0.0/16"
-  log_retention                 = 90
+  log_retention                 = 365
 }
 
 locals {

--- a/govwifi/wifi/locals.tf
+++ b/govwifi/wifi/locals.tf
@@ -7,7 +7,7 @@ locals {
   dublin_backend_vpc_cidr_block  = "10.42.0.0/16"
   dublin_frontend_vpc_cidr_block = "10.43.0.0/16"
   london_backend_vpc_cidr_block  = "10.84.0.0/16"
-  log_retention                  = 90
+  log_retention                  = 365
 }
 
 locals {


### PR DESCRIPTION
### What
increase the retention period for logs from 3 to 12 months for live and from 1 to 3 months on Staging.

### Why
At the request of the TA, to allow investigations into any incidents.


### Link to JIRA card (if applicable): 
[GW-2334](https://technologyprogramme.atlassian.net/browse/GW-2334)